### PR TITLE
Fixes issue #118; update versions of dependencies

### DIFF
--- a/module-03/ksql-quickstart/description.md
+++ b/module-03/ksql-quickstart/description.md
@@ -48,7 +48,7 @@ Let's run the Confluent platform consisting of Zookeeper, Kafka, KSQL server and
         -e STREAMS_SCHEMA_REGISTRY_HOST=schema-registry \
         -e STREAMS_SCHEMA_REGISTRY_PORT=8081 \
         --network ksql-quickstart_demo-net \
-        confluentinc/ksql-cli:4.1.0 /bin/bash
+        confluentinc/ksql-cli:5.0.0 /bin/bash
     ```
 
     We're running the KSQL CLI from withing a container that we have attached to the network `ksql-quickstart_demo-net` on which the Confluent platform runs.
@@ -135,7 +135,7 @@ For more details please see the [quick start](https://docs.confluent.io/current/
     ```bash
     $ docker container run -it --rm \
         --network ksql-quickstart_demo-net \
-        confluentinc/cp-enterprise-kafka:4.1.0 kafka-console-consumer \
+        confluentinc/cp-enterprise-kafka:5.0.0 kafka-console-consumer \
             --topic pageviews \
             --bootstrap-server kafka:29092 \
             --from-beginning \
@@ -148,7 +148,7 @@ For more details please see the [quick start](https://docs.confluent.io/current/
     ```bash
     $ docker container run -it --rm \
         --network ksql-quickstart_demo-net \
-        confluentinc/cp-enterprise-kafka:4.1.0 kafka-console-consumer \
+        confluentinc/cp-enterprise-kafka:5.0.0 kafka-console-consumer \
             --topic users \
             --bootstrap-server kafka:29092 \
             --from-beginning \
@@ -160,7 +160,7 @@ For more details please see the [quick start](https://docs.confluent.io/current/
     ```bash
     $ docker container run -it --rm \
         --network ksql-quickstart_demo-net \
-        confluentinc/cp-enterprise-kafka:4.1.0 kafka-console-producer \
+        confluentinc/cp-enterprise-kafka:5.0.0 kafka-console-producer \
             --topic t1 \
             --broker-list kafka:29092 \
             --property parse.key=true \
@@ -182,7 +182,7 @@ For more details please see the [quick start](https://docs.confluent.io/current/
     ```bash
     $ docker container run -it --rm \
         --network ksql-quickstart_demo-net \
-        confluentinc/cp-enterprise-kafka:4.1.0 kafka-console-producer \
+        confluentinc/cp-enterprise-kafka:5.0.0 kafka-console-producer \
             --topic t2 \
             --broker-list kafka:29092  \
             --property parse.key=true \
@@ -206,7 +206,7 @@ For more details please see the [quick start](https://docs.confluent.io/current/
     ```bash
     $ docker container run -it --rm \
         --network ksql-quickstart_demo-net \
-        confluentinc/cp-enterprise-kafka:4.1.0 kafka-topics \
+        confluentinc/cp-enterprise-kafka:5.0.0 kafka-topics \
             --zookeeper zookeeper:32181 \
             --list
     ```

--- a/module-03/ksql-quickstart/docker-compose.yml
+++ b/module-03/ksql-quickstart/docker-compose.yml
@@ -21,7 +21,8 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
       CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka:9092"
-
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100
+      
   schema-registry:
     image: "confluentinc/cp-schema-registry:5.0.0"
     networks:

--- a/module-09/gradle-sample/build.gradle
+++ b/module-09/gradle-sample/build.gradle
@@ -26,7 +26,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
 }
 

--- a/module-09/gradle-sample/src/main/java/streams/MapSample.java
+++ b/module-09/gradle-sample/src/main/java/streams/MapSample.java
@@ -4,7 +4,7 @@ import java.util.Properties;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;

--- a/module-09/maven-sample/pom.xml
+++ b/module-09/maven-sample/pom.xml
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>1.1.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>1.1.0</version>
+            <version>2.0.0</version>
         </dependency>
     </dependencies>
 

--- a/module-09/maven-sample/src/main/java/streams/MapSample.java
+++ b/module-09/maven-sample/src/main/java/streams/MapSample.java
@@ -4,7 +4,7 @@ import java.util.Properties;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;

--- a/module-10/join-sample/build.gradle
+++ b/module-10/join-sample/build.gradle
@@ -26,6 +26,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
 }

--- a/module-10/join-sample/src/main/java/streams/JoinSample.java
+++ b/module-10/join-sample/src/main/java/streams/JoinSample.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;

--- a/module-10/json-sample/build.gradle
+++ b/module-10/json-sample/build.gradle
@@ -26,8 +26,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
     compile group: "org.slf4j", name: "slf4j-log4j12", version: "1.7.25"
-    compile group: "io.confluent", name: "kafka-serde-tools-package", version: "4.1.0"
+    compile group: "io.confluent", name: "kafka-serde-tools-package", version: "5.0.0"
 }

--- a/module-10/json-sample/src/main/java/streams/JsonSample.java
+++ b/module-10/json-sample/src/main/java/streams/JsonSample.java
@@ -8,7 +8,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsBuilder;

--- a/module-10/processor-sample/build.gradle
+++ b/module-10/processor-sample/build.gradle
@@ -26,6 +26,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
 }

--- a/module-11/simple-test/build.gradle
+++ b/module-11/simple-test/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
     testCompile group: 'junit', name: 'junit', version: '4.+'
-    testCompile group: 'org.apache.kafka', name: 'kafka-streams-test-utils', version: '1.1.0'
+    testCompile group: 'org.apache.kafka', name: 'kafka-streams-test-utils', version: '2.0.0'
 }

--- a/module-11/simple-test/src/main/java/io/confluent/training/streams/CustomMaxAggregatorSupplier.java
+++ b/module-11/simple-test/src/main/java/io/confluent/training/streams/CustomMaxAggregatorSupplier.java
@@ -51,9 +51,6 @@ public class CustomMaxAggregatorSupplier implements ProcessorSupplier<String, Lo
         }
     
         @Override
-        public void punctuate(long timestamp) {} // deprecated; not used
-    
-        @Override
         public void close() {}
     }    
 

--- a/module-11/wordcount-test/build.gradle
+++ b/module-11/wordcount-test/build.gradle
@@ -6,13 +6,13 @@ repositories {
 }
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
     compile group: "org.apache.avro", name: "avro", version: "1.8.2"
-    compile group: "io.confluent", name: "kafka-streams-avro-serde", version: "4.1.0"
-    compile group: "io.confluent", name: "kafka-avro-serializer", version: "4.1.0"
-    compile group: "io.confluent", name: "kafka-schema-registry", version: "4.1.0"
-    compile group: "io.confluent", name: "kafka-schema-registry-client", version: "4.1.0"
+    compile group: "io.confluent", name: "kafka-streams-avro-serde", version: "5.0.0"
+    compile group: "io.confluent", name: "kafka-avro-serializer", version: "5.0.0"
+    compile group: "io.confluent", name: "kafka-schema-registry", version: "5.0.0"
+    compile group: "io.confluent", name: "kafka-schema-registry-client", version: "5.0.0"
    
     testCompile group: 'junit', name: 'junit', version: '4.+'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.3.0'
@@ -20,10 +20,10 @@ dependencies {
     testCompile group: 'org.apache.curator', name: 'curator-test', version: '2.9.1'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.11.v20180605'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.11.v20180605'
-    testCompile group: "org.apache.kafka", name: "kafka_2.11", version: "1.1.0"
-    testCompile group: "org.apache.kafka", name: "kafka_2.11", version: "1.1.0", classifier: "test"
-    testCompile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    testCompile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0", classifier: "test"
-    testCompile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0", classifier: "test"
-    testCompile group: "io.confluent", name: "kafka-schema-registry", version: "4.1.0", classifier: "tests"
+    testCompile group: "org.apache.kafka", name: "kafka_2.11", version: "2.0.0"
+    testCompile group: "org.apache.kafka", name: "kafka_2.11", version: "2.0.0", classifier: "test"
+    testCompile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    testCompile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0", classifier: "test"
+    testCompile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0", classifier: "test"
+    testCompile group: "io.confluent", name: "kafka-schema-registry", version: "5.0.0", classifier: "tests"
 }

--- a/module-12/jmx-sample/build.gradle
+++ b/module-12/jmx-sample/build.gradle
@@ -26,7 +26,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
 }
 

--- a/module-12/jmx-sample/src/main/java/streams/MapSample.java
+++ b/module-12/jmx-sample/src/main/java/streams/MapSample.java
@@ -4,7 +4,7 @@ import java.util.Properties;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;

--- a/module-12/processor-sample/build.gradle
+++ b/module-12/processor-sample/build.gradle
@@ -26,7 +26,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
-    compile group: "io.confluent", name: "monitoring-interceptors", version: "4.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
+    compile group: "io.confluent", name: "monitoring-interceptors", version: "5.0.0"
 }

--- a/module-12/processor-sample/src/main/java/streams/WordCountProcessorSupplier.java
+++ b/module-12/processor-sample/src/main/java/streams/WordCountProcessorSupplier.java
@@ -52,11 +52,6 @@ public class WordCountProcessorSupplier implements ProcessorSupplier<String, Str
             }
             context.commit();
         }
-
-        @Override
-        public void punctuate(long timestamp) {
-            // this method is deprecated and should not be used anymore
-        }
     
         @Override
         public void close() {}

--- a/module-12/word-count/build.gradle
+++ b/module-12/word-count/build.gradle
@@ -26,6 +26,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
 }

--- a/module-13/secure-app/build.gradle
+++ b/module-13/secure-app/build.gradle
@@ -26,7 +26,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
-    compile group: "io.confluent", name: "monitoring-interceptors", version: "4.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
+    compile group: "io.confluent", name: "monitoring-interceptors", version: "5.0.0"
 }

--- a/module-14/streams-app/build.gradle
+++ b/module-14/streams-app/build.gradle
@@ -26,8 +26,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
-    compile group: "org.apache.kafka", name: "kafka-streams", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
+    compile group: "org.apache.kafka", name: "kafka-streams", version: "2.0.0"
     compile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.5"
-    compile group: "io.confluent", name: "monitoring-interceptors", version: "4.1.0"
+    compile group: "io.confluent", name: "monitoring-interceptors", version: "5.0.0"
 }

--- a/module-14/streams-app/src/main/java/io/confluent/training/streams/StreamsApp.java
+++ b/module-14/streams-app/src/main/java/io/confluent/training/streams/StreamsApp.java
@@ -15,7 +15,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.Windowed;

--- a/module-14/temp-producer/build.gradle
+++ b/module-14/temp-producer/build.gradle
@@ -26,5 +26,5 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: "org.apache.kafka", name: "kafka-clients", version: "1.1.0"
+    compile group: "org.apache.kafka", name: "kafka-clients", version: "2.0.0"
 }


### PR DESCRIPTION
Replaced old versions of Kafka and Confluent components with newest ones.
From Issue #118 (https://github.com/confluentinc/training-ksql-and-streams/issues/118)