### PR TITLE
Fixed use of deprecated config class

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -5,7 +5,7 @@ for FILE in $FILES
 do
     DIR=$(dirname $FILE)
     cd $DIR
-    echo "\n\n\n*** Compiling project in $DIR"
+    printf "\n\n\n*** Compiling project in $DIR\n"
     docker container run --rm \
         -v "$PWD":/home/gradle/project \
         -v "$HOME"/.gradle:/root/.gradle \

--- a/module-09/gradle-sample/src/main/java/streams/MapSample.java
+++ b/module-09/gradle-sample/src/main/java/streams/MapSample.java
@@ -18,30 +18,26 @@ public class MapSample {
     public static void main(String[] args) {
         System.out.println("*** Starting Map Sample Application ***");
 	
-	Properties settings = new Properties();
-	settings.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-sample-v0.1.0");
-	settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
-	StreamsConfig config = new StreamsConfig(settings);
+        Properties settings = new Properties();
+        settings.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-sample-v0.1.0");
+        settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
 
-final Serde<String> stringSerde = Serdes.String();
-StreamsBuilder builder = new StreamsBuilder();
-KStream<String, String> lines = builder
-    .stream("lines-topic", Consumed.with(stringSerde, stringSerde));
-KStream<String, String> transformed = lines
-    .map((key, value) -> KeyValue.pair(key, value.toLowerCase()));
-transformed.to("lines-lower-topic", Produced.with(stringSerde, stringSerde));
-Topology topology = builder.build();
+        final Serde<String> stringSerde = Serdes.String();
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> lines = builder
+            .stream("lines-topic", Consumed.with(stringSerde, stringSerde));
+        KStream<String, String> transformed = lines
+            .map((key, value) -> KeyValue.pair(key, value.toLowerCase()));
+        transformed.to("lines-lower-topic", Produced.with(stringSerde, stringSerde));
+        Topology topology = builder.build();
 
-KafkaStreams streams = new KafkaStreams(topology, config);
-streams.start();
+        KafkaStreams streams = new KafkaStreams(topology, settings);
+        streams.start();
 
-Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-    System.out.println("### Stopping Map Sample Application ###");
-    streams.close();
-}));
-
-        // here will be the Kafka Streams application code
-
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("### Stopping Map Sample Application ###");
+            streams.close();
+        }));
     }
 }
 

--- a/module-09/maven-sample/src/main/java/streams/MapSample.java
+++ b/module-09/maven-sample/src/main/java/streams/MapSample.java
@@ -21,7 +21,6 @@ public class MapSample {
         Properties settings = new Properties();
         settings.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-sample-v0.1.0");
         settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
-        StreamsConfig config = new StreamsConfig(settings);
 
         final Serde<String> stringSerde = Serdes.String();
         StreamsBuilder builder = new StreamsBuilder();
@@ -30,7 +29,7 @@ public class MapSample {
         transformed.to("lines-lower-topic", Produced.with(stringSerde, stringSerde));
         Topology topology = builder.build();
         
-        KafkaStreams streams = new KafkaStreams(topology, config);
+        KafkaStreams streams = new KafkaStreams(topology, settings);
         streams.start();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/module-10/join-sample/src/main/java/streams/JoinSample.java
+++ b/module-10/join-sample/src/main/java/streams/JoinSample.java
@@ -25,7 +25,7 @@ public class JoinSample {
     public static void main(String[] args) {
         System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
 
-        StreamsConfig config = getConfig();
+        Properties config = getConfig();
         Topology topology = getTopology();
         KafkaStreams streams =  startApp(config, topology);
 
@@ -54,15 +54,14 @@ public class JoinSample {
         return topology;
     }
 
-    private static StreamsConfig getConfig(){
+    private static Properties getConfig(){
         Properties settings = new Properties();
         settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
         settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
-        StreamsConfig config = new StreamsConfig(settings);
-        return config;        
+        return settings;        
     }
 
-    private static KafkaStreams startApp(StreamsConfig config, Topology topology){
+    private static KafkaStreams startApp(Properties config, Topology topology){
         KafkaStreams streams = new KafkaStreams(topology, config);
         streams.start();
         return streams;

--- a/module-10/json-sample/src/main/java/streams/JsonSample.java
+++ b/module-10/json-sample/src/main/java/streams/JsonSample.java
@@ -31,7 +31,7 @@ public class JsonSample {
     public static void main(String[] args) {
         System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
 
-        StreamsConfig config = getConfig();
+        Properties config = getConfig();
         Topology topology = getTopology();
         KafkaStreams streams =  startApp(config, topology);
 
@@ -67,15 +67,14 @@ public class JsonSample {
         return Serdes.serdeFrom(temperatureSerializer, temperatureDeserializer);
     }
 
-    private static StreamsConfig getConfig(){
+    private static Properties getConfig(){
         Properties settings = new Properties();
         settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
         settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
-        StreamsConfig config = new StreamsConfig(settings);
-        return config;        
+        return settings;        
     }
 
-    private static KafkaStreams startApp(StreamsConfig config, Topology topology){
+    private static KafkaStreams startApp(Properties config, Topology topology){
         KafkaStreams streams = new KafkaStreams(topology, config);
         streams.start();
         return streams;

--- a/module-10/processor-sample/src/main/java/streams/ProcessorSample.java
+++ b/module-10/processor-sample/src/main/java/streams/ProcessorSample.java
@@ -17,7 +17,7 @@ public class ProcessorSample {
     public static void main(String[] args) {
         System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
 
-        StreamsConfig config = getConfig();
+        Properties config = getConfig();
         Topology topology = getTopology();
         KafkaStreams streams =  startApp(config, topology);
 
@@ -39,7 +39,7 @@ public class ProcessorSample {
         return builder;
     }
 
-    private static StreamsConfig getConfig(){
+    private static Properties getConfig(){
         Properties settings = new Properties();
         settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
         settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
@@ -48,11 +48,10 @@ public class ProcessorSample {
         settings.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         // setting offset reset to earliest so that we can re-run the demo code with the same pre-loaded data
         settings.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        StreamsConfig config = new StreamsConfig(settings);
-        return config;        
+        return settings;        
     }
 
-    private static KafkaStreams startApp(StreamsConfig config, Topology topology){
+    private static KafkaStreams startApp(Properties config, Topology topology){
         KafkaStreams streams = new KafkaStreams(topology, config);
         streams.start();
         return streams;

--- a/module-12/jmx-sample/src/main/java/streams/MapSample.java
+++ b/module-12/jmx-sample/src/main/java/streams/MapSample.java
@@ -18,30 +18,26 @@ public class MapSample {
     public static void main(String[] args) {
         System.out.println("*** Starting Map Sample Application ***");
 	
-	Properties settings = new Properties();
-	settings.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-sample-v0.1.0");
-	settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
-	StreamsConfig config = new StreamsConfig(settings);
+        Properties settings = new Properties();
+        settings.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-sample-v0.1.0");
+        settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
 
-final Serde<String> stringSerde = Serdes.String();
-StreamsBuilder builder = new StreamsBuilder();
-KStream<String, String> lines = builder
-    .stream("lines-topic", Consumed.with(stringSerde, stringSerde));
-KStream<String, String> transformed = lines
-    .map((key, value) -> KeyValue.pair(key, value.toLowerCase()));
-transformed.to("lines-lower-topic", Produced.with(stringSerde, stringSerde));
-Topology topology = builder.build();
+        final Serde<String> stringSerde = Serdes.String();
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> lines = builder
+            .stream("lines-topic", Consumed.with(stringSerde, stringSerde));
+        KStream<String, String> transformed = lines
+            .map((key, value) -> KeyValue.pair(key, value.toLowerCase()));
+        transformed.to("lines-lower-topic", Produced.with(stringSerde, stringSerde));
+        Topology topology = builder.build();
 
-KafkaStreams streams = new KafkaStreams(topology, config);
-streams.start();
+        KafkaStreams streams = new KafkaStreams(topology, settings);
+        streams.start();
 
-Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-    System.out.println("### Stopping Map Sample Application ###");
-    streams.close();
-}));
-
-        // here will be the Kafka Streams application code
-
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("### Stopping Map Sample Application ###");
+            streams.close();
+        }));
     }
 }
 

--- a/module-12/processor-sample/src/main/java/streams/ProcessorSample.java
+++ b/module-12/processor-sample/src/main/java/streams/ProcessorSample.java
@@ -18,7 +18,7 @@ public class ProcessorSample {
     public static void main(String[] args) {
         System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
 
-        StreamsConfig config = getConfig();
+        Properties config = getConfig();
         Topology topology = getTopology();
         KafkaStreams streams =  startApp(config, topology);
 
@@ -40,7 +40,7 @@ public class ProcessorSample {
         return builder;
     }
 
-    private static StreamsConfig getConfig(){
+    private static Properties getConfig(){
         Properties settings = new Properties();
         settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
         settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
@@ -53,11 +53,10 @@ public class ProcessorSample {
             "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor");
         settings.put(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
             "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor");
-        StreamsConfig config = new StreamsConfig(settings);
-        return config;        
+        return settings;        
     }
 
-    private static KafkaStreams startApp(StreamsConfig config, Topology topology){
+    private static KafkaStreams startApp(Properties config, Topology topology){
         KafkaStreams streams = new KafkaStreams(topology, config);
         streams.start();
         return streams;

--- a/module-12/word-count/src/main/java/io/confluent/training/streams/ConfigProvider.java
+++ b/module-12/word-count/src/main/java/io/confluent/training/streams/ConfigProvider.java
@@ -6,12 +6,12 @@ import org.apache.kafka.streams.StreamsConfig;
 import java.util.Properties;
 
 public class ConfigProvider {
-    public StreamsConfig getConfig(String bootstrapServers) {
+    public Properties getConfig(String bootstrapServers) {
         Properties config = new Properties();
         config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "wordCount");
         config.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        return new StreamsConfig(config);
+        return config;
     }
 }

--- a/module-12/word-count/src/main/java/io/confluent/training/streams/WordCountSample.java
+++ b/module-12/word-count/src/main/java/io/confluent/training/streams/WordCountSample.java
@@ -3,12 +3,13 @@ package io.confluent.training.streams;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import java.util.Properties;
 
 public class WordCountSample {
     public static void main(String[] args) throws InterruptedException {
         System.out.println("*** Starting Word Count Sample Application ***");
 
-        StreamsConfig config = new ConfigProvider().getConfig("kafka:9092");
+        Properties config = new ConfigProvider().getConfig("kafka:9092");
         Topology topology = new TopologyProvider().getTopology();
         KafkaStreams streams = new KafkaStreams(topology, config);
         streams.start();

--- a/module-14/streams-app/src/main/java/io/confluent/training/streams/StreamsApp.java
+++ b/module-14/streams-app/src/main/java/io/confluent/training/streams/StreamsApp.java
@@ -38,14 +38,14 @@ public class StreamsApp {
     public static void main(String[] args) {
         System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
 
-        StreamsConfig config = getConfig();
+        Properties config = getConfig();
         Topology topology = getTopology();
         KafkaStreams streams =  startApp(config, topology);
 
         setupShutdownHook(streams);
     }
 
-    private static StreamsConfig getConfig(){
+    private static Properties getConfig(){
         Properties settings = new Properties();
         settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
         settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
@@ -56,8 +56,7 @@ public class StreamsApp {
         settings.put(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
             "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor");
 
-        StreamsConfig config = new StreamsConfig(settings);
-        return config;        
+        return settings;        
     }
 
     private static Topology getTopology() {
@@ -92,7 +91,7 @@ public class StreamsApp {
         return Serdes.serdeFrom(serializer, deserializer);
     }
 
-    private static KafkaStreams startApp(StreamsConfig config, Topology topology){
+    private static KafkaStreams startApp(Properties config, Topology topology){
         KafkaStreams streams = new KafkaStreams(topology, config);
         streams.start();
         return streams;


### PR DESCRIPTION
In most Java code samples we used the deprecated `StreamsConfig` to wrap the settings. This has been corrected