### PR TITLE
Issue 174: Added log4j.properties to simple-test

### DIFF
--- a/module-11/simple-test/src/main/resources/log4j.properties
+++ b/module-11/simple-test/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=WARN, stdout
+ 
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.err
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Fixed issue 174 (https://github.com/confluentinc/training-ksql-and-streams/issues/174)
Also mentioned in issue 189 (https://github.com/confluentinc/training-ksql-and-streams/issues/189)