### PR TITLE
Fix code for use with new code that copies from solution

### DIFF
--- a/module-10/join-sample/JoinSample.java_
+++ b/module-10/join-sample/JoinSample.java_
@@ -1,0 +1,66 @@
+package streams;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+
+public class JoinSample {
+    final static String APPLICATION_ID = "join-sample-v0.1.0";
+    final static String APPLICATION_NAME = "Join Sample";
+
+    public static void main(String[] args) {
+        System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
+
+        StreamsConfig config = getConfig();
+        Topology topology = getTopology();
+        KafkaStreams streams =  startApp(config, topology);
+
+        setupShutdownHook(streams);
+    }
+
+    private static Topology getTopology(){
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final Serde<String> stringSerde = Serdes.String();
+
+        // TODO: here we construct the Kafka Streams topology
+
+        Topology topology = builder.build();
+        return topology;
+    }
+
+    private static StreamsConfig getConfig(){
+        Properties settings = new Properties();
+        settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
+        settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        StreamsConfig config = new StreamsConfig(settings);
+        return config;        
+    }
+
+    private static KafkaStreams startApp(StreamsConfig config, Topology topology){
+        KafkaStreams streams = new KafkaStreams(topology, config);
+        streams.start();
+        return streams;
+    }
+
+    private static void setupShutdownHook(KafkaStreams streams){
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.printf("### Stopping %s Application ###%n", APPLICATION_NAME);
+            streams.close();
+        }));
+    }
+}

--- a/module-10/json-sample/JsonSample.java_
+++ b/module-10/json-sample/JsonSample.java_
@@ -1,0 +1,77 @@
+package streams;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import io.confluent.kafka.serializers.KafkaJsonSerializer;
+import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+
+public class JsonSample {
+    final static String APPLICATION_ID = "json-sample-v0.1.0";
+    final static String APPLICATION_NAME = "JSON Sample";
+
+    // POJO class
+    static public class TempReading {
+        public String station;
+        public Double temperature;
+        public Long timestamp;
+    }
+
+    public static void main(String[] args) {
+        System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
+
+        StreamsConfig config = getConfig();
+        Topology topology = getTopology();
+        KafkaStreams streams =  startApp(config, topology);
+
+        setupShutdownHook(streams);
+    }
+
+    private static Topology getTopology(){
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final Serde<String> stringSerde = Serdes.String();
+        final Serde<TempReading> temperatureSerde = getJsonSerde();
+
+        // TODO: here we construct the Kafka Streams topology
+
+        Topology topology = builder.build();
+        return topology;
+    }
+
+    private static Serde<TempReading> getJsonSerde(){
+        // TODO: create the JSON serde
+    }
+
+    private static StreamsConfig getConfig(){
+        Properties settings = new Properties();
+        settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
+        settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        StreamsConfig config = new StreamsConfig(settings);
+        return config;        
+    }
+
+    private static KafkaStreams startApp(StreamsConfig config, Topology topology){
+        KafkaStreams streams = new KafkaStreams(topology, config);
+        streams.start();
+        return streams;
+    }
+
+    private static void setupShutdownHook(KafkaStreams streams){
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.printf("### Stopping %s Application ###%n", APPLICATION_NAME);
+            streams.close();
+        }));
+    }
+}

--- a/module-10/processor-sample/ProcessorSample.java_
+++ b/module-10/processor-sample/ProcessorSample.java_
@@ -1,0 +1,55 @@
+package streams;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.state.Stores;
+
+public class ProcessorSample {
+    final static String APPLICATION_ID = "processor-sample-v0.1.0";
+    final static String APPLICATION_NAME = "Processor API Sample";
+
+    public static void main(String[] args) {
+        System.out.printf("*** Starting %s Application ***%n", APPLICATION_NAME);
+
+        Properties config = getConfig();
+        Topology topology = getTopology();
+        KafkaStreams streams =  startApp(config, topology);
+
+        setupShutdownHook(streams);
+    }
+
+    private static Topology getTopology(){
+        // TODO: here we construct the Kafka Streams topology
+    }
+
+    private static Properties getConfig(){
+        Properties settings = new Properties();
+        settings.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
+        settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        settings.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        settings.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        settings.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        // setting offset reset to earliest so that we can re-run the demo code with the same pre-loaded data
+        settings.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return settings;        
+    }
+
+    private static KafkaStreams startApp(Properties config, Topology topology){
+        KafkaStreams streams = new KafkaStreams(topology, config);
+        streams.start();
+        return streams;
+    }
+
+    private static void setupShutdownHook(KafkaStreams streams){
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.printf("### Stopping %s Application ###%n", APPLICATION_NAME);
+            streams.close();
+        }));
+    }
+}

--- a/module-10/processor-sample/WordCountProcessorSupplier.java_
+++ b/module-10/processor-sample/WordCountProcessorSupplier.java_
@@ -1,0 +1,39 @@
+package streams;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.Punctuator;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+import java.util.Locale;
+import java.util.Properties;
+
+public class WordCountProcessorSupplier implements ProcessorSupplier<String, String> {
+    public class WordCountProcessor implements Processor<String, String> {
+        private ProcessorContext context;
+        private KeyValueStore<String, Integer> kvStore;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void init(final ProcessorContext context) {
+            // TODO
+        }
+
+        @Override
+        public void process(String dummy, String line) {
+            // TODO
+        }
+    
+        @Override
+        public void close() {}
+    }
+
+    @Override
+    public Processor<String, String> get() {
+        return new WordCountProcessor();
+    }
+}

--- a/module-11/simple-test/ProcessorTest.java_
+++ b/module-11/simple-test/ProcessorTest.java_
@@ -1,0 +1,48 @@
+package streams;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.Topology;
+
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.test.ConsumerRecordFactory;
+import org.apache.kafka.streams.test.OutputVerifier;
+
+import java.util.*;
+
+import org.junit.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class ProcessorTest {
+    private TopologyTestDriver testDriver;
+    private KeyValueStore<String, Long> store;
+    
+    private StringDeserializer stringDeserializer = new StringDeserializer();
+    private LongDeserializer longDeserializer = new LongDeserializer();
+    private ConsumerRecordFactory<String, Long> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new LongSerializer());
+    
+    @Before
+    public void setup() {
+        TopologyProvider provider = new TopologyProvider();
+        Topology topology = provider.getTopology();
+    
+        ConfigProvider configProvider = new ConfigProvider();
+        Properties config = configProvider.getConfig("dummy:1234");
+
+        testDriver = new TopologyTestDriver(topology, config);
+    
+        // pre-populate store
+        store = testDriver.getKeyValueStore("aggStore");
+        store.put("a", 21L);
+    }
+    
+    @After
+    public void tearDown() {
+        testDriver.close();
+    }
+}

--- a/module-11/simple-test/src/main/java/streams/ConfigProvider.java
+++ b/module-11/simple-test/src/main/java/streams/ConfigProvider.java
@@ -1,6 +1,5 @@
-package io.confluent.training.streams;
+package streams;
 
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsConfig;
 import java.util.Properties;
@@ -8,10 +7,10 @@ import java.util.Properties;
 public class ConfigProvider {
     public Properties getConfig(String bootstrapServers) {
         Properties config = new Properties();
-        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "wordCount");
+        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "maxAggregation");
         config.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        config.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long().getClass().getName());
         return config;
     }
 }

--- a/module-11/simple-test/src/main/java/streams/CustomMaxAggregatorSupplier.java
+++ b/module-11/simple-test/src/main/java/streams/CustomMaxAggregatorSupplier.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;

--- a/module-11/simple-test/src/main/java/streams/TopologyProvider.java
+++ b/module-11/simple-test/src/main/java/streams/TopologyProvider.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.state.Stores;

--- a/module-11/simple-test/src/test/java/io/confluent/streams/ProcessorTest.java
+++ b/module-11/simple-test/src/test/java/io/confluent/streams/ProcessorTest.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;

--- a/module-11/wordcount-test/TopologyProviderTest.java_
+++ b/module-11/wordcount-test/TopologyProviderTest.java_
@@ -1,0 +1,71 @@
+package streams;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat; 
+
+public class TopologyProviderTest {
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    private static final String inputTopic = "lines-topic";
+    private static final String outputTopic = "word-count-topic";
+
+    @BeforeClass
+    public static void startKafkaCluster() throws Exception {
+        CLUSTER.createTopic(inputTopic);
+        CLUSTER.createTopic(outputTopic);
+    }
+
+    @Test
+    public void shouldCountWords() throws Exception {
+        // Step 1: Get Kafka Streams application configuration
+        Properties streamsConfiguration = getStreamsConfiguration();
+
+        // Step 2: Get the Kafka Streams application topology.
+        TopologyProvider provider = new TopologyProvider();
+        Topology topology = provider.getTopology();
+
+        // Step 3: Initialize and start the streaming application
+        KafkaStreams streams = new KafkaStreams(topology, streamsConfiguration);
+        streams.start();
+
+        // Step 4: Produce some input data to the input topic.
+        produceInputData();
+
+        // Step 5: Verify the application's output data.
+        verifyOutputData(streams);
+    }
+
+    private Properties getStreamsConfiguration() {
+      // TODO: add code
+    }
+
+    private void produceInputData() throws Exception {
+      // TODO: add code
+    }
+
+    private void verifyOutputData(KafkaStreams streams) throws Exception {
+      // TODO: add code
+    }
+}

--- a/module-11/wordcount-test/src/main/java/streams/TopologyProvider.java
+++ b/module-11/wordcount-test/src/main/java/streams/TopologyProvider.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;

--- a/module-11/wordcount-test/src/test/java/streams/TopologyProviderTest.java
+++ b/module-11/wordcount-test/src/test/java/streams/TopologyProviderTest.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/module-12/word-count/src/main/java/streams/ConfigProvider.java
+++ b/module-12/word-count/src/main/java/streams/ConfigProvider.java
@@ -1,5 +1,6 @@
-package io.confluent.training.streams;
+package streams;
 
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsConfig;
 import java.util.Properties;
@@ -7,10 +8,10 @@ import java.util.Properties;
 public class ConfigProvider {
     public Properties getConfig(String bootstrapServers) {
         Properties config = new Properties();
-        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "maxAggregation");
+        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "wordCount");
         config.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        config.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-        config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long().getClass().getName());
+        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         return config;
     }
 }

--- a/module-12/word-count/src/main/java/streams/MetricsReporter.java
+++ b/module-12/word-count/src/main/java/streams/MetricsReporter.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/module-12/word-count/src/main/java/streams/TopologyProvider.java
+++ b/module-12/word-count/src/main/java/streams/TopologyProvider.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;

--- a/module-12/word-count/src/main/java/streams/WordCountSample.java
+++ b/module-12/word-count/src/main/java/streams/WordCountSample.java
@@ -1,4 +1,4 @@
-package io.confluent.training.streams;
+package streams;
 
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;


### PR DESCRIPTION
We need to have clean code since instead of downloading files from a Gist we're now copying from this sample solution that the user is supposed to first clone into their folder `~/confluent-labs/solution`